### PR TITLE
Feature custom css

### DIFF
--- a/e2e/single.html
+++ b/e2e/single.html
@@ -17,11 +17,6 @@
     -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="./single.js"></script>
-    <style>
-      *::part(row) {
-        color: red !important;
-      }
-    </style>
   </head>
 
   <body class="h-full">

--- a/e2e/single.html
+++ b/e2e/single.html
@@ -17,6 +17,11 @@
     -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="./single.js"></script>
+    <style>
+      *::part(row) {
+        color: red !important;
+      }
+    </style>
   </head>
 
   <body class="h-full">

--- a/e2e/zea-tree-view_custom.css
+++ b/e2e/zea-tree-view_custom.css
@@ -1,3 +1,3 @@
 tr {
-  border: 5px solid greenyellow !important;
+  border: 2px dashed red;
 }

--- a/e2e/zea-tree-view_custom.css
+++ b/e2e/zea-tree-view_custom.css
@@ -1,0 +1,3 @@
+tr {
+  border: 5px solid greenyellow !important;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import {
   InstanceItem,
   VisibilityChangedEvent,
 } from '@zeainc/zea-engine'
-// import type { ChildAddedEvent } from '@zeainc/zea-engine'
 import {
   SelectionManager,
   UndoRedoManager,
@@ -150,14 +149,16 @@ class ZeaTreeView extends HTMLElement {
         visibility: hidden;
       }
 
-      .toggle-expanded {
+      .toggle-expanded,
+      .toggle-collapsed {
         background: none;
         border: none;
         color: var(--zea-tree-button-text-color, black);
         width: 20px;
       }
 
-      .toggle-expanded:hover {
+      .toggle-expanded:hover,
+      .toggle-collapsed:hover {
         background-color: var(--zea-tree-button-bg-color, silver);
         border-radius: 2px;
       }
@@ -390,7 +391,7 @@ class ZeaTreeView extends HTMLElement {
     const hasChildren = children.length
 
     const $toggleExpanded = document.createElement('button')
-    $toggleExpanded.classList.add('toggle-expanded')
+    $toggleExpanded.classList.add(isExpanded ? 'toggle-expanded' : 'toggle-collapsed')
     if (this.isSearching || !hasChildren) {
       $toggleExpanded.classList.add('invisible')
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ class ZeaTreeView extends HTMLElement {
   private isSearching = false
   // private isTheFirstRender = true
   private $styleTag = document.createElement('style')
+  private $slotTag = document.createElement('slot')
   private $tableWrapper = document.createElement('div')
   private $thead = document.createElement('thead')
   private $tbody = document.createElement('tbody')
@@ -47,6 +48,8 @@ class ZeaTreeView extends HTMLElement {
 
     this.shadowRoot?.appendChild(this.$styleTag)
     this.setStyles()
+    this.$slotTag.setAttribute('name', 'overload')
+    this.shadowRoot?.appendChild(this.$slotTag)
 
     // Main wrapper.
     const $mainWrapper = document.createElement('div')
@@ -136,6 +139,7 @@ class ZeaTreeView extends HTMLElement {
    */
   private setStyles(): void {
     this.$styleTag.textContent = `
+      @import "zea-tree-view_custom.css";
       .MainWrapper {
         --search-wrapper-height: 35px;
 
@@ -248,7 +252,7 @@ class ZeaTreeView extends HTMLElement {
   /**
    * Toggle an item's visibility.
    */
-  private setVisibilityOf(item: TreeItem, isVisible: boolean): void {
+  private static setVisibilityOf(item: TreeItem, isVisible: boolean): void {
     try {
       const undoRedoManager = UndoRedoManager.getInstance()
 
@@ -314,6 +318,8 @@ class ZeaTreeView extends HTMLElement {
     $parentItemRow?: HTMLTableRowElement
   ): void {
     const $row = document.createElement('tr')
+    $row.setAttribute('part', 'row')
+
     // @ts-ignore
     $row.treeItem = treeItem
     $row.title = this.getTooltipFor(treeItem)
@@ -407,7 +413,7 @@ class ZeaTreeView extends HTMLElement {
     $toggleVisible.checked = treeItem.visibleParam.value
     $toggleVisible.addEventListener('click', (event) => {
       event.stopPropagation()
-      this.setVisibilityOf(treeItem, !treeItem.visibleParam.value)
+      ZeaTreeView.setVisibilityOf(treeItem, !treeItem.visibleParam.value)
     })
     if (!treeItem.isVisible()) $row.classList.add('invisible-item')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ class ZeaTreeView extends HTMLElement {
   private isSearching = false
   // private isTheFirstRender = true
   private $styleTag = document.createElement('style')
-  private $slotTag = document.createElement('slot')
   private $tableWrapper = document.createElement('div')
   private $thead = document.createElement('thead')
   private $tbody = document.createElement('tbody')
@@ -47,8 +46,6 @@ class ZeaTreeView extends HTMLElement {
 
     this.shadowRoot?.appendChild(this.$styleTag)
     this.setStyles()
-    this.$slotTag.setAttribute('name', 'overload')
-    this.shadowRoot?.appendChild(this.$slotTag)
 
     // Main wrapper.
     const $mainWrapper = document.createElement('div')

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,7 +316,6 @@ class ZeaTreeView extends HTMLElement {
     $parentItemRow?: HTMLTableRowElement
   ): void {
     const $row = document.createElement('tr')
-    $row.setAttribute('part', 'row')
 
     // @ts-ignore
     $row.treeItem = treeItem


### PR DESCRIPTION
Hello, we have an issue with customizing the tree from outside (because of the Shadow DOM of the WebComponent).
As it is now, we are limited to the css variables that you are using, that means we can only change some colors.

We have made some studies and tests, and we found 2 "good" ways to do it.
But both need some minor modifications in your source code.

- Part pseudo class : https://developer.mozilla.org/fr/docs/Web/CSS/::part
You have to add the attribute to your element 
`const $row = document.createElement('tr'); $row.setAttribute('part', 'row')`

Pro(s) : not invasive, simple. You control exactly what customization you want to allow.
Con(s) : you can only apply style to the exact element, not his children. You have to explicitly declare the attribute where you want to customize something.

- Import external stylesheet : https://css-tricks.com/styling-a-web-component/#aa-link-to-external-styles-instead
Add this to the CSS 
`@import "zea-tree-view_custom.css";`
And your server has to provide this resource with this exact URL

Pro(s) : you can do anything as if it was outside of the WebComponent!
Con(s) : if your server does not provide the resource with the right path, you will end up with an error in your Network tab (not blocking). You cannot control which customization you want to allow.